### PR TITLE
Major version bump due to major bump in packages: invenio-rdm-records, oarepo-model, oarepo-rdm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,19 +4,19 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ccmm-invenio"
-version = "1.1.11"
+version = "1.1.12"
 description = "CCMM (Czech Core Metadata Model) components for NRP Invenio"
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.14,<3.15"
 dependencies = [
     "oarepo[rdm,tests]>=14.0.0,<15.0.0",
-    "oarepo-model>=3.0.0,<4.0.0",
-    "oarepo-rdm>=6.0.0,<7.0.0",
+    "oarepo-model>=4.0.0,<5.0.0",
+    "oarepo-rdm>=7.0.0,<8.0.0",
     "langdetect>=1.0.9",
 
     # invenio dependencies
-    "invenio-rdm-records>=29.0.0,<30.0.0",
+    "invenio-rdm-records>=31.0.0,<32.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Major version bump due to major bump in packages: invenio-rdm-records, oarepo-model, oarepo-rdm.
