### PR TITLE
BE-1141: Fix metadata-only toggle permissions in deposit form

### DIFF
--- a/src/ccmm_invenio/ui/semantic-ui/js/ccmm_invenio/forms/CCMMFiles.js
+++ b/src/ccmm_invenio/ui/semantic-ui/js/ccmm_invenio/forms/CCMMFiles.js
@@ -14,7 +14,7 @@ export const CCMMFiles = {
   },
   component: (tabConfig) => {
     const { record, formConfig } = tabConfig;
-    const { filesLocked, permissions } = formConfig.config;
+    const { filesLocked, permissions } = formConfig;
     const { overridableIdPrefix } = formConfig;
     return (
       <Overridable id={buildUID(overridableIdPrefix, "Files")} {...tabConfig}>
@@ -23,7 +23,7 @@ export const CCMMFiles = {
           config={formConfig}
           quota={formConfig?.config?.quota}
           decimalSizeDisplay={formConfig.decimal_size_display}
-          allowEmptyFiles={formConfig.allow_empty_files}
+          allowEmptyFiles={formConfig.allowEmptyFiles}
           fileUploadConcurrency={formConfig.file_upload_concurrency}
           showMetadataOnlyToggle={permissions?.can_manage_files}
           filesLocked={filesLocked}


### PR DESCRIPTION
## Summary

Fixes a bug where the "Metadata-only record" checkbox was always visible in the deposit form, regardless of the user's permissions.

## Root Cause

`CCMMFiles.js` read `permissions` from `formConfig.config` (the nested config object) where they are `undefined`. This caused `showMetadataOnlyToggle` to fall back to its default `true`, rendering the toggle for all users — even when `can_manage_files` is `false`.

The same file also read `allowEmptyFiles` using the wrong key (`formConfig.allow_empty_files` instead of `formConfig.allowEmptyFiles`), so the backend `RECORDS_RESOURCES_ALLOW_EMPTY_FILES = False` setting was not propagated to the uploader.

## Changes

- Read `permissions` and `filesLocked` from `formConfig` (the `FormConfigProvider` context value) instead of `formConfig.config`.
- Read `allowEmptyFiles` using the correct camelCase key.

## Validation

Playwright-validated on local datarepo instance:
- Regular community owner: metadata-only checkbox **not visible** ✓
- `records-resources-allow-empty-files` hidden input = `false` ✓
- Admin (superuser): checkbox visible (Invenio superuser bypass — by design), backend guard still prevents metadata-only submissions.

## Related

- config PR: https://github.com/oarepo/oarepo-config