### PR TITLE
Pass fileModification prop to UppyUploader in files section

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ production_dataset = model(
         {
             "Metadata": {
                 "properties": {
-                    # your extensions come here, ccmm_production_preset will add 
+                    # your extensions come here, ccmm_production_preset will add
                     # all ccmm fields automatically
                 },
             },
@@ -43,7 +43,7 @@ production_dataset = model(
 )
 
 # invenio.cfg
-production_dataset.register() 
+production_dataset.register()
 ```
 
 ## How to generate new NMA and Production CCMM model mappings

--- a/ccmm_versions/src/ccmm_versions/__init__.py
+++ b/ccmm_versions/src/ccmm_versions/__init__.py
@@ -1,1 +1,9 @@
+#
+# Copyright (c) 2026 CESNET z.s.p.o.
+#
+# This file is a part of ccmm-versions (see https://github.com/NRP-CZ/ccmm-invenio).
+#
+# ccmm-versions is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
 """Scripts for pre-processing CCMM xsd definitions."""

--- a/ccmm_versions/src/ccmm_versions/clean_all.py
+++ b/ccmm_versions/src/ccmm_versions/clean_all.py
@@ -1,3 +1,11 @@
+#
+# Copyright (c) 2026 CESNET z.s.p.o.
+#
+# This file is a part of ccmm-versions (see https://github.com/NRP-CZ/ccmm-invenio).
+#
+# ccmm-versions is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
 """Normalize XML Schema files.
 
 The normalization removes annotations, sorts elements and attributes,

--- a/ccmm_versions/src/ccmm_versions/create_schema_overview.py
+++ b/ccmm_versions/src/ccmm_versions/create_schema_overview.py
@@ -1,3 +1,11 @@
+#
+# Copyright (c) 2026 CESNET z.s.p.o.
+#
+# This file is a part of ccmm-versions (see https://github.com/NRP-CZ/ccmm-invenio).
+#
+# ccmm-versions is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
 """Create an overview of the schema types in the given directory."""
 
 import dataclasses

--- a/ccmm_versions/src/ccmm_versions/diff_ccmm.py
+++ b/ccmm_versions/src/ccmm_versions/diff_ccmm.py
@@ -1,3 +1,11 @@
+#
+# Copyright (c) 2026 CESNET z.s.p.o.
+#
+# This file is a part of ccmm-versions (see https://github.com/NRP-CZ/ccmm-invenio).
+#
+# ccmm-versions is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
 """Diff CCMM schemas between two releases."""
 
 import subprocess

--- a/ccmm_versions/src/ccmm_versions/get_previous_version.py
+++ b/ccmm_versions/src/ccmm_versions/get_previous_version.py
@@ -1,3 +1,11 @@
+#
+# Copyright (c) 2026 CESNET z.s.p.o.
+#
+# This file is a part of ccmm-versions (see https://github.com/NRP-CZ/ccmm-invenio).
+#
+# ccmm-versions is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
 """Get previous version to the given one."""
 
 from pathlib import Path

--- a/ccmm_versions/src/ccmm_versions/identify_anonymous_types.py
+++ b/ccmm_versions/src/ccmm_versions/identify_anonymous_types.py
@@ -1,3 +1,11 @@
+#
+# Copyright (c) 2026 CESNET z.s.p.o.
+#
+# This file is a part of ccmm-versions (see https://github.com/NRP-CZ/ccmm-invenio).
+#
+# ccmm-versions is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
 """Identify anonymous types in XSD files."""
 
 from pathlib import Path

--- a/ccmm_versions/src/ccmm_versions/merge_schemas.py
+++ b/ccmm_versions/src/ccmm_versions/merge_schemas.py
@@ -1,3 +1,11 @@
+#
+# Copyright (c) 2026 CESNET z.s.p.o.
+#
+# This file is a part of ccmm-versions (see https://github.com/NRP-CZ/ccmm-invenio).
+#
+# ccmm-versions is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+#
 """Normalize XML Schema files.
 
 The normalization removes annotations, sorts elements and attributes,

--- a/src/ccmm_invenio/conversion/ccmm_sparql.py
+++ b/src/ccmm_invenio/conversion/ccmm_sparql.py
@@ -70,7 +70,7 @@ def join_with_commas(prop: str, parent: dict[str, Any]) -> None:
 class SPARQLReader(VocabularyReader):
     """Download rdf locally, enrich it and call sparql to convert the RDF to Invenio YAML format."""
 
-    def __init__(  # noqa: PLR0913
+    def __init__(  # noqa: PLR0913, PLR0917
         self,
         name: str,
         endpoint: str,

--- a/src/ccmm_invenio/parsers/base.py
+++ b/src/ccmm_invenio/parsers/base.py
@@ -579,10 +579,10 @@ class CCMMXMLParser:
         path: list[QualifiedTag],
         cardinality: Literal["single", "optional", "array", "optional_array"] = "single",
         **kwargs: Any,
-    ) -> str | None | list[str]:
+    ) -> str | list[str] | None:
         """Parse a simple text element."""
         return cast(
-            "str | None | list[str]",
+            "str | list[str] | None",
             self.parse_field(
                 tag,
                 children,

--- a/src/ccmm_invenio/ui/semantic-ui/js/ccmm_invenio/forms/CCMMFiles.js
+++ b/src/ccmm_invenio/ui/semantic-ui/js/ccmm_invenio/forms/CCMMFiles.js
@@ -14,8 +14,8 @@ export const CCMMFiles = {
   },
   component: (tabConfig) => {
     const { record, formConfig } = tabConfig;
-    const { filesLocked, permissions } = formConfig;
-    const { overridableIdPrefix } = formConfig;
+    const { filesLocked, permissions, fileModification, overridableIdPrefix } =
+      formConfig;
     return (
       <Overridable id={buildUID(overridableIdPrefix, "Files")} {...tabConfig}>
         <UppyUploader
@@ -27,6 +27,7 @@ export const CCMMFiles = {
           fileUploadConcurrency={formConfig.file_upload_concurrency}
           showMetadataOnlyToggle={permissions?.can_manage_files}
           filesLocked={filesLocked}
+          fileModification={fileModification}
         />
       </Overridable>
     );


### PR DESCRIPTION
## What
Threads the `fileModification` form-config value into `<UppyUploader>` in the files section (`CCMMFiles.js`), so the file-modification grace-period unlock UI (the "Edit files" accordion added in the invenio-rdm-records Uppy uploader) is surfaced.

```jsx
const { filesLocked, permissions, fileModification } = formConfig.config;
...
<UppyUploader ... fileModification={fileModification} />
```

The `fileModification` value is produced by oarepo-rdm's `FileModificationComponent`. Companion PRs: oarepo-rdm, oarepo-ui, oarepo-config, and the invenio-rdm-records fork branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)