### PR TITLE
fix: remove empty description from OP_DATPRO file type

### DIFF
--- a/src/ccmm_invenio/fixtures/ccmm_file_types.yaml
+++ b/src/ccmm_invenio/fixtures/ccmm_file_types.yaml
@@ -1244,8 +1244,7 @@
   title:
     cs: ODT
     en: ODT
-- description: {}
-  id: OP_DATPRO
+- id: OP_DATPRO
   props:
     iri: http://publications.europa.eu/resource/authority/file-type/OP_DATPRO
   title:


### PR DESCRIPTION
## Problem

Reading the `filetypes` vocabulary (e.g. the filetypes suggester in the deposit form, or a record referencing a file type) crashes with:

```
File ".../marshmallow_utils/fields/babel.py", line 214, in gettext_from_dict
    return list(catalog.values())[0]
IndexError: list index out of range
```

The `OP_DATPRO` entry in `ccmm_file_types.yaml` has `description: {}`. When the vocabulary UI serializer renders that empty i18n dict, `gettext_from_dict` falls through to its last-resort `list(catalog.values())[0]`, which raises `IndexError` on an empty dict.

## Fix

Remove the empty `description` key from `OP_DATPRO` (the field is simply absent, not `{}`). This is the same fix applied to the language vocabulary in `672f6f3` ("removed empty title/description from language items").

The `SPARQLReader` already guards against this (`del term["description"]` when empty), but this fixture predates that guard and was never regenerated, so the empty dict lingered.

## Apply

Re-import the `filetypes` vocabulary from the fixture so the stored `OP_DATPRO` entry drops the empty description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)