### PR TITLE
Add RDMCompleteRecordUISchemaPreset to ccmm production preset

### DIFF
--- a/src/ccmm_invenio/models/__init__.py
+++ b/src/ccmm_invenio/models/__init__.py
@@ -35,6 +35,9 @@ from oarepo_model.customizations import (
 )
 from oarepo_model.presets import Preset
 from oarepo_rdm.model.presets import rdm_minimal_preset
+from oarepo_rdm.model.presets.rdm.services.records.rdm_record_ui_schema import (
+    RDMCompleteRecordUISchemaPreset,
+)
 from oarepo_rdm.model.presets.rdm_metadata import merge_metadata
 
 from ccmm_invenio.parsers.production_1_1_0 import CCMMXMLProductionParser
@@ -305,6 +308,7 @@ ccmm_nma_preset_1_1_0 = [
 
 ccmm_production_preset_1_1_0 = [
     *rdm_minimal_preset,
+    RDMCompleteRecordUISchemaPreset,
     CCMMProductionPreset,
     CCMMImportPreset,
     CCMMIndexSettingsPreset,


### PR DESCRIPTION
## Problem

Records served by ccmm models come back with **empty UI serialization for vocabulary-backed fields**. For example, two records with identical, valid `metadata.rights` (CC BY) serialize differently in the `ui` block:

- `metadata.rights` → correct in both (id, cs/en title, description, icon)
- `ui.rights` → **`[{}]`** (empty), and `ui.dates[].type` → **`{}`** (empty)

The frontend therefore renders a blank/missing license and date type, even though the underlying metadata is fine.

## Root cause

`ccmm_production_preset_1_1_0` is built on **`rdm_minimal_preset`**. The RDM UI serialization lives in two separate presets in `oarepo-rdm`:

- `RDMRecordUISchemaPreset` (partial) — only stashes the serialized record in a contextvar / adds `version`. It's included via `rdm_static_preset`, so minimal/basic get it. It does **not** localize vocabulary fields.
- `RDMCompleteRecordUISchemaPreset` (complete) — prepends RDM's `UIRecordSchema`, which is what actually localizes `rights`, `dates[].type`, etc. into `title_l10n` / `description_l10n` / `icon`.

Crucially, **neither `rdm_minimal_preset` nor `rdm_basic_preset` contains the complete RDM UI schema** — only `rdm_complete_preset` includes `RDMCompleteRecordUISchemaPreset`:

```python
# oarepo_rdm/model/presets/__init__.py
rdm_complete_preset = [ *rdm_static_preset, ..., RDMCompleteRecordUISchemaPreset ]  # ✅ has it
rdm_basic_preset    = [ *rdm_static_preset, RDMBasicMetadataPreset ]                # ❌
rdm_minimal_preset  = [ *rdm_static_preset, RDMMinimalMetadataPreset ]             # ❌
```

Since ccmm builds on minimal, no ccmm model gets vocabulary localization out of the box. Until now the only model that worked was one that manually added `PrependMixin("RecordUISchema", UIRecordSchema)` in its own `model.py` — a per-model hand-patch that other models (fram, atlas_itk, particles, …) never received.

## Fix

Add `RDMCompleteRecordUISchemaPreset` directly to `ccmm_production_preset_1_1_0`. This pulls in the full RDM UI schema for **every** ccmm model at the preset level, so `ui.rights` / `ui.dates` are localized consistently and no model needs the manual prepend anymore.

## Notes

- Downstream models that currently hand-add `PrependMixin("RecordUISchema", UIRecordSchema)` can drop it after this ships (it becomes redundant).
- Only the production preset is changed here; `ccmm_nma_preset_1_1_0` is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)